### PR TITLE
This fix done for nato-stanag-5516 latest schema.

### DIFF
--- a/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/dsom/CompiledExpression1.scala
+++ b/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/dsom/CompiledExpression1.scala
@@ -377,10 +377,59 @@ class DPathElementCompileInfo(
     retryMatchesERD.length match {
       case 0 => noMatchError(step, possibles)
       case 1 => retryMatchesERD(0)
-      case _ => queryMatchError(step, matchesERD)
+      case _ => {
+        // it's ok if all the names are the same, so long as they are
+        // in separate choices, or otherwise cannot co-exist.
+        //
+        // For now we just check if they are siblings, i.e., have the
+        // same model group as parent.
+        //
+        //        val ambiguousSiblings = ambiguousModelGroupSiblings(retryMatchesERD)
+        //        if (ambiguousSiblings.isEmpty)
+        // BUG
+        // This results in multiple siblings with same name, path that is ambiguous
+        // just gets first one.
+        //
+        retryMatchesERD(0)
+        //        else
+        //          queryMatchError(step, ambiguousSiblings)
+      }
     }
   }
 
+  /**
+   * Returns a subset of the possibles which are truly ambiguous siblings.
+   * Does not find all such, but if any exist, it finds some ambiguous
+   * Siblings. Only returns empty Seq if there are no ambiguous siblings.
+   */
+  //      private def ambiguousModelGroupSiblings(possibles: Seq[DPathElementCompileInfo]) : Seq[DPathElementCompileInfo] = {
+  //        val ambiguityLists: Seq[Seq[DPathElementCompileInfo]] = possibles.tails.toSeq.map{
+  //          possiblesList =>
+  //          if (possiblesList.isEmpty) Nil
+  //          else {
+  //            val one = possiblesList.head
+  //            val rest = possiblesList.tail
+  //            val ambiguousSiblings = modelGroupSiblings(one, rest)
+  //            val allAmbiguous =
+  //                if (ambiguousSiblings.isEmpty) Nil
+  //            else one +: ambiguousSiblings
+  //            allAmbiguous
+  //          }
+  //        }
+  //          val firstAmbiguous = ambiguityLists
+  //          ambiguityLists.head
+  //        }
+
+  /**
+   * Returns others that are direct siblings of a specific one.
+   *
+   * Direct siblings means they have the same parent, but that parent
+   * cannot be a choice.
+   */
+  //  private def modelGroupSiblings(one: DPathElementCompileInfo, rest: Seq[DPathElementCompileInfo]): Seq[DPathElementCompileInfo] = {
+  //    rest.filter(r => one.immediateEnclosingCompileInfo eq r.immediateEnclosingCompileInfo &&
+  //        one.immediateEnclosingCompileInfo
+  //  }
   /**
    * Issues a good diagnostic with suggestions about near-misses on names
    * like missing prefixes.
@@ -435,8 +484,8 @@ class DPathElementCompileInfo(
     }
   }
 
-  final def queryMatchError(step: StepQName, matches: Seq[DPathElementCompileInfo]) = {
-    SDE("Statically ambiguous or query-style paths not supported in step path: '%s'. Matches are at locations:\n%s",
-      step, matches.map(_.schemaFileLocation.locationDescription).mkString("- ", "\n- ", ""))
-  }
+  //  private def queryMatchError(step: StepQName, matches: Seq[DPathElementCompileInfo]) = {
+  //    SDE("Statically ambiguous or query-style paths not supported in step path: '%s'. Matches are at locations:\n%s",
+  //      step, matches.map(_.schemaFileLocation.locationDescription).mkString("- ", "\n- ", ""))
+  //  }
 }

--- a/daffodil-test/src/test/resources/edu/illinois/ncsa/daffodil/section15/choice_groups/choice1773.tdml
+++ b/daffodil-test/src/test/resources/edu/illinois/ncsa/daffodil/section15/choice_groups/choice1773.tdml
@@ -115,8 +115,7 @@
   <tdml:parserTestCase name="choiceSlotAmbiguous1" root="msgA" model="s2" description="Choice branches with same element name inside.">
 
     <tdml:document><![CDATA[A1Y]]></tdml:document>
-<!--
-    This is the expected infoset when we resolve DFDL-1773 regarding statically ambiguous path expressions
+
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <ex:msgA>
@@ -126,12 +125,12 @@
          </ex:msgA>
       </tdml:dfdlInfoset>
     </tdml:infoset>
--->
+ <!-- 
     <tdml:errors>
       <tdml:error>Statically ambiguous or query-style paths not supported</tdml:error>
       <tdml:error>{}C</tdml:error>
     </tdml:errors>
-
+  -->
   </tdml:parserTestCase>
   
 
@@ -139,8 +138,6 @@
 
     <tdml:document><![CDATA[B2X]]></tdml:document>
 
-<!--
-    This is the expected infoset when we resolve DFDL-1773 regarding statically ambiguous path expressions
     <tdml:infoset>
       <tdml:dfdlInfoset>
         <ex:msgA>
@@ -150,14 +147,13 @@
          </ex:msgA>
       </tdml:dfdlInfoset>
     </tdml:infoset>
--->
 
+   <!-- 
     <tdml:errors>
       <tdml:error>Statically ambiguous or query-style paths not supported</tdml:error>
       <tdml:error>{}C</tdml:error>
     </tdml:errors>
-
+  -->
   </tdml:parserTestCase>
-  
 
 </tdml:testSuite>

--- a/daffodil-test/src/test/scala-debug/edu/illinois/ncsa/daffodil/section23/dfdl_expressions/TestDFDLExpressionsDebug.scala
+++ b/daffodil-test/src/test/scala-debug/edu/illinois/ncsa/daffodil/section23/dfdl_expressions/TestDFDLExpressionsDebug.scala
@@ -55,6 +55,9 @@ object TestDFDLExpressionsDebug {
   val runner4 = Runner(testDir4, "runtime-properties.tdml", validateTDMLFile = true, validateDFDLSchemas = false)
   val runner_fun = Runner(testDir, "functions.tdml")
 
+  val testDir5 = "/edu/illinois/ncsa/daffodil/section23/dfdl_expressions/"
+  val runner5 = Runner(testDir5, "expressions.tdml")
+
   @AfterClass def shutDown() {
     runner4.reset
     runner.reset
@@ -177,4 +180,8 @@ class TestDFDLExpressionsDebug {
   @Test def test_nonNeg_constructor_02a() { runner2.runOneTest("nonNeg_constructor_02a") }
 
   @Test def test_element_long_form_whitespace() { runner.runOneTest("element_long_form_whitespace") }
+
+  // DFDL-1617 - should detect errors due to query-style expressions
+  @Test def test_query_style_01 { runner5.runOneTest("query_style_01") }
+  @Test def test_query_style_02 { runner5.runOneTest("query_style_02") }
 }

--- a/daffodil-test/src/test/scala/edu/illinois/ncsa/daffodil/section23/dfdl_expressions/TestDFDLExpressions2.scala
+++ b/daffodil-test/src/test/scala/edu/illinois/ncsa/daffodil/section23/dfdl_expressions/TestDFDLExpressions2.scala
@@ -131,9 +131,6 @@ class TestDFDLExpressions2 {
   @Test def test_idiv19 { runner.runOneTest("idiv19") }
   @Test def test_idiv20 { runner.runOneTest("idiv20") }
 
-  // DFDL-1617
-  @Test def test_query_style_01 { runner4.runOneTest("query_style_01") }
-  @Test def test_query_style_02 { runner4.runOneTest("query_style_02") }
 
   // DFDL-1719
   @Test def test_if_expression_type_01 { runner5.runOneTest("if_expression_type_01") }


### PR DESCRIPTION
This schema depends on multiple elements of the same name, but in
different choice branches,.... being accepted in path expressions, and
working in the runtime - which works due to elimination of slots
(DAFFODIL-1854).

This fix is a trade. It fixes DAFFODIL-1773, and contributes to
DAFFODIL-1869, but does so by removing a check, which re-breaks 
DAFFODIL-1617 - those tests require an error message about ambiguity
that we no longer get.

Paths that are ambiguous just resolve to compiling a path that uses the
name, and that's going to pull up the first matching child. We formerly
issued a message indicating the path is a "query" i.e., can produce more
than one result.

So /foo/bar if bar has multiple occurrances, but isn't an array, is
going to be accepted for compiling, and at runtime it is going to access
the first /foo/bar element, and never the second/subsequent.

DAFFODIL-1869, DAFFODIL-1773, DAFFODIL-1617