### PR TITLE
Optimizations with Infoset HashMap lookups/insertions

### DIFF
--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dpath/Expression.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dpath/Expression.scala
@@ -1123,6 +1123,7 @@ case class NamedStep(s: String, predArg: Option[PredicateExpression])
       }.getOrElse(die)
       e
     }
+    stepElem.isReferencedByExpressions = true
     stepElem
   }
 }

--- a/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/ElementBase.scala
+++ b/daffodil-core/src/main/scala/edu/illinois/ncsa/daffodil/dsom/ElementBase.scala
@@ -557,7 +557,6 @@ trait ElementBase
       //
       // unparser specific items
       //
-      false, // !isReferencedByExpressions, // assume it is always to be referenced by expressions
       optTruncateSpecifiedLengthString,
       if (isOutputValueCalc) Some(ovcCompiledExpression) else None,
       maybeBinaryFloatRepEv,

--- a/daffodil-core/src/test/scala/edu/illinois/ncsa/daffodil/infoset/TestInfoset.scala
+++ b/daffodil-core/src/test/scala/edu/illinois/ncsa/daffodil/infoset/TestInfoset.scala
@@ -56,9 +56,11 @@ object TestInfoset {
    * classes.
    */
 
-  def elem2Infoset(erd: ElementRuntimeData, xmlElem: scala.xml.Node, tunable: DaffodilTunables = DaffodilTunables()): InfosetElement = {
+  private val tunableForTests = DaffodilTunables("allowExternalPathExpressions", "true")
+
+  def elem2Infoset(erd: ElementRuntimeData, xmlElem: scala.xml.Node): InfosetElement = {
     val ic = new ScalaXMLInfosetInputter(xmlElem)
-    ic.initialize(erd, tunable)
+    ic.initialize(erd, tunableForTests)
     val aacc = ic.advanceAccessor
     Assert.invariant(ic.advance == true)
     val infosetRootNode = aacc.node

--- a/daffodil-core/src/test/scala/edu/illinois/ncsa/daffodil/infoset/TestInfosetCursorFromReader2.scala
+++ b/daffodil-core/src/test/scala/edu/illinois/ncsa/daffodil/infoset/TestInfosetCursorFromReader2.scala
@@ -138,7 +138,6 @@ class TestInfosetInputterFromReader2 {
       val arr = bar_s.getChildArray(foo_1_s.runtimeData)
       if (arr.length % 100L =#= 0L) {
         // println("array length is " + arr.length)
-        bar_s.resetChildArray(0)
         foo_arr_s.reduceToSize(0)
       }
       arr.asInstanceOf[DIArray].children

--- a/daffodil-lib/src/main/scala/edu/illinois/ncsa/daffodil/api/DaffodilTunables.scala
+++ b/daffodil-lib/src/main/scala/edu/illinois/ncsa/daffodil/api/DaffodilTunables.scala
@@ -111,7 +111,16 @@ case class DaffodilTunables(
   //
   val initialElementOccurrencesHint: Long = 10,
   val unqualifiedPathStepPolicy: UnqualifiedPathStepPolicy.Type = UnqualifiedPathStepPolicy.NoNamespace,
-  val suppressSchemaDefinitionWarnings: List[WarnID] = Nil)
+  val suppressSchemaDefinitionWarnings: List[WarnID] = Nil,
+
+  // By default, path expressions in Daffodil will only work correctly if path
+  // steps are used in an expression defined in the schema when compiled. To
+  // enable the use of other expressions (e.g. during debugging, where not all
+  // expressions are known at schema compile time), set this tunable to true.
+  // This may cause a degredation of performance in path expression evaluation,
+  // so this should be avoided when in production. This flag is automatically
+  // enabled when debugging is enabled.
+  val allowExternalPathExpressions: Boolean = false)
   extends Serializable
   with Logging
   with DataStreamLimits {
@@ -211,6 +220,7 @@ case class DaffodilTunables(
         }
         this.copy(suppressSchemaDefinitionWarnings = warningsList)
       }
+      case "allowexternalpathexpressions" => this.copy(allowExternalPathExpressions = java.lang.Boolean.valueOf(value))
       case _ => {
         log(LogLevel.Warning, "Ignoring unknown tunable: %s", tunable)
         this

--- a/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/dsom/CompiledExpression1.scala
+++ b/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/dsom/CompiledExpression1.scala
@@ -333,6 +333,15 @@ class DPathElementCompileInfo(
     elementChildrenCompileInfo
   }
 
+  /**
+   * Stores whether or not this element is used in any path step expressions
+   * during schema compilation. Note that this needs to be a var since its
+   * value is determined during DPath compilation, which requires that the
+   * DPathElementCompileInfo already exists. So this must be a mutable value
+   * that can be flipped during schema compilation.
+   */
+  var isReferencedByExpressions = false
+
   override def toString = "DPathElementCompileInfo(%s)".format(name)
 
   @throws(classOf[java.io.IOException])

--- a/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/processors/Runtime.scala
+++ b/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/processors/Runtime.scala
@@ -141,6 +141,7 @@ class DataProcessor(val ssrd: SchemaSetRuntimeData)
 
   def setDebugging(flag: Boolean) {
     areDebugging_ = flag
+    setTunable("allowExternalPathExpressions", flag.toString)
   }
 
   def setExternalVariables(extVars: Map[String, String]): Unit = {

--- a/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/processors/RuntimeData.scala
+++ b/daffodil-runtime1/src/main/scala/edu/illinois/ncsa/daffodil/processors/RuntimeData.scala
@@ -662,12 +662,6 @@ final class ElementRuntimeData(
   //
   // Unparser-specific arguments
   //
-  /**
-   * pass true for this if the corresponding infoset element is never
-   * accessed by way of expressions. Enables the element to be dropped
-   * from the infoset immediately after unparsing is complete.
-   */
-  @TransientParam notReferencedByExpressionsArg: => Boolean,
   @TransientParam optTruncateSpecifiedLengthStringArg: => Option[Boolean],
   @TransientParam outputValueCalcExprArg: => Option[CompiledExpression[AnyRef]],
   @TransientParam maybeBinaryFloatRepEvArg: => Maybe[BinaryFloatRepEv],
@@ -710,13 +704,10 @@ final class ElementRuntimeData(
   lazy val namedQName = namedQNameArg
   lazy val impliedRepresentation = impliedRepresentationArg
   lazy val optDefaultValue = optDefaultValueArg
-  lazy val notReferencedByExpressions = notReferencedByExpressionsArg
   lazy val optTruncateSpecifiedLengthString = optTruncateSpecifiedLengthStringArg
   lazy val outputValueCalcExpr = outputValueCalcExprArg
   lazy val maybeBinaryFloatRepEv = maybeBinaryFloatRepEvArg
   lazy val maybeByteOrderEv = maybeByteOrderEvArg
-
-  def isReferencedByExpressions = !notReferencedByExpressions
 
   override def preSerialization: Unit = {
     super.preSerialization
@@ -750,7 +741,6 @@ final class ElementRuntimeData(
     namedQName
     impliedRepresentation
     optDefaultValue
-    notReferencedByExpressions
     optTruncateSpecifiedLengthString
     outputValueCalcExpr
     maybeBinaryFloatRepEv


### PR DESCRIPTION
- Add a new variable to DPathElementCompileInfo that keeps track of
  which path steps are used in an expression. Because the variable is
  set when expression are compiled, which relies on the
  DPathElementCompileInfo already existing, this new variable is a var
  that is toggled during expression compilation. This replaces the
  notReferencedByExpressions in the ElementRuntimeData, which isn't
  actually used, and can't work since the ERD must exist before
  expression compilation.
- Use this new variable to only insert elements into the Infoset fast
  lookup hash map if that flag is set and thus might be needed in an
  expression. This minimizes the number of hash insertions, greatly
  improving performance.
- Add a new tunable, allowExternalPathExpressions, which allows one to
  evaluate expression on path steps that were not compiled at schema
  compilation time (e.g. using expressions when debugging). When this
  tunable is true and a path step is not found in the fast lookup hash
  map, a slower linear search is performed to see if the element exists.
  This is slower, but should only occur when debugging/testing. This
  tunable is automatically set when debugging is enabled.
- Remove the resetChildArray function. This isn't used anywhere and is
  not adequately tested, and it isn't clear what it is supposed to do.
- In the hashmap, rather than checking if the hashmap containsKey()
  and then calling get() if true, just call get() and check for null for
  existence. This avoids an extra hash lookup.
- Use += rather than append() to add to an ArrayBuffer. The append() takes a
  vararg, which causes scala to allocate a WrappedArray for a single
  element. Instead, use += which avoids that allocation. Similary,
  instead of the companion object ArrayBuffer(), which uses a vararg
  constructor, just use "new ArrayBuffer()" and append to it using +=,
  also avoiding a WrappedArray allocation.
- Use reduceToSize rather than dropRight with the ArrayBuffer. dropRight
  is more general and slower than reduceToSize.
- Make the childNodes array non-lazy. The vast majority of complex
  elements will end up using the array and causing it to be allocated,
  so this removes all the lazy checks to determine if it was initialized
  or not.

DAFFODIL-1860